### PR TITLE
Fix unary operators

### DIFF
--- a/nanoMorphoByacc/ava7.nm
+++ b/nanoMorphoByacc/ava7.nm
@@ -1,0 +1,31 @@
+ava_add(){
+  writeln("1 + 1");
+  writeln(1 + 1);
+}
+
+ava_sub(){
+  writeln("1 - 1");
+  writeln(1 - 1);
+
+  writeln("2 - 1");
+  writeln(2 - 1);
+
+  writeln("1 - 2");
+  writeln(   1 - 2);
+
+  writeln("1 - 4 * 3");
+  writeln(1 - 4 * 3);
+
+  writeln("-(5*4+2)");
+  writeln(-(5*4+2));
+}
+
+ava_bool() {
+  writeln(!true);
+}
+
+main() {
+    ava_add();
+    ava_sub();
+    ava_bool();
+}

--- a/nanoMorphoByacc/makefile
+++ b/nanoMorphoByacc/makefile
@@ -24,13 +24,13 @@ test: NanoMorphoParser.class NanoMorphoLexer.class NanoMorphoParserVal.class
 	echo "Testing parser"
 	java NanoMorphoParser test_success.s
 
-Generate_morpho:
+Generate_morpho: NanoMorphoParser.class NanoMorphoLexer.class NanoMorphoParserVal.class
 	echo ""
 	echo ""
 	echo "Generating morpho from the test file"
 	java NanoMorphoParser test_success.s | java -jar morpho.jar -c
 
-Test_morpho_generated_code:
+Test_morpho_generated_code: Generate_morpho
 	echo ""
 	echo ""
 	echo "Executing the morpho code"

--- a/nanoMorphoByacc/makefile
+++ b/nanoMorphoByacc/makefile
@@ -1,3 +1,9 @@
+NanoMorphoParser.class NanoMorphoLexer.class NanoMorphoParserVal.class: NanoMorphoParser.java NanoMorphoParserVal.java
+	echo ""
+	echo ""
+	echo "Compiling to java"
+	javac NanoMorphoParser.java NanoMorphoLexer.java NanoMorphoParserVal.java
+
 clear:
 	clear
 
@@ -10,13 +16,6 @@ NanoMorphoParser.java NanoMorphoParserVal.java: NanoMorpho.java
 	echo ""
 	echo "Byacc result: "
 	byaccj -Jclass=NanoMorphoParser nanoMorpho.byaccj
-
-
-NanoMorphoParser.class NanoMorphoLexer.class NanoMorphoParserVal.class: NanoMorphoParser.java NanoMorphoParserVal.java
-	echo ""
-	echo ""
-	echo "Compiling to java"
-	javac NanoMorphoParser.java NanoMorphoLexer.java NanoMorphoParserVal.java
 
 test: NanoMorphoParser.class NanoMorphoLexer.class NanoMorphoParserVal.class
 	echo ""

--- a/nanoMorphoByacc/makefile
+++ b/nanoMorphoByacc/makefile
@@ -5,20 +5,20 @@ NanoMorpho.java:
 	echo "Jflex result: "
 	java -jar jflex-full-1.7.0.jar nanoMorpho.jflex
 
-NanoMorphoParser.java NanoMorphoParserVal.java:
+NanoMorphoParser.java NanoMorphoParserVal.java: NanoMorpho.java
 	echo ""
 	echo ""
 	echo "Byacc result: "
-	./byacc -Jclass=NanoMorphoParser nanoMorpho.byaccj
+	byaccj -Jclass=NanoMorphoParser nanoMorpho.byaccj
 
 
-NanoMorphoParser.class NanoMorphoLexer.class NanoMorphoParserVal.class:
+NanoMorphoParser.class NanoMorphoLexer.class NanoMorphoParserVal.class: NanoMorphoParser.java NanoMorphoParserVal.java
 	echo ""
 	echo ""
 	echo "Compiling to java"
 	javac NanoMorphoParser.java NanoMorphoLexer.java NanoMorphoParserVal.java
 
-test:
+test: NanoMorphoParser.class NanoMorphoLexer.class NanoMorphoParserVal.class
 	echo ""
 	echo ""
 	echo "Testing parser"

--- a/nanoMorphoByacc/makefile
+++ b/nanoMorphoByacc/makefile
@@ -36,5 +36,17 @@ Test_morpho_generated_code: Generate_morpho
 	echo "Executing the morpho code"
 	java -jar morpho.jar test_success
 
+gen_ava: NanoMorphoParser.class NanoMorphoLexer.class NanoMorphoParserVal.class
+	echo ""
+	echo ""
+	echo "Generating ava7's nanomorpho"
+	java NanoMorphoParser ava7.nm | java -jar morpho.jar -c
+
+test_ava: gen_ava
+	echo ""
+	echo ""
+	echo "Testing ava7's nanomorpho"
+	java -jar morpho.jar ava7
+
 clean:
 	rm -rf *.class *~ *.mexe *.bak yacc.* *.java

--- a/nanoMorphoByacc/makefile
+++ b/nanoMorphoByacc/makefile
@@ -1,50 +1,50 @@
 NanoMorphoParser.class NanoMorphoLexer.class NanoMorphoParserVal.class: NanoMorphoParser.java NanoMorphoParserVal.java
-	echo ""
-	echo ""
-	echo "Compiling to java"
+	@echo ""
+	@echo ""
+	@echo "Compiling to java"
 	javac NanoMorphoParser.java NanoMorphoLexer.java NanoMorphoParserVal.java
 
 clear:
 	clear
 
 NanoMorpho.java:
-	echo "Jflex result: "
+	@echo "Jflex result: "
 	java -jar jflex-full-1.7.0.jar nanoMorpho.jflex
 
 NanoMorphoParser.java NanoMorphoParserVal.java: NanoMorpho.java
-	echo ""
-	echo ""
-	echo "Byacc result: "
+	@echo ""
+	@echo ""
+	@echo "Byacc result: "
 	byaccj -Jclass=NanoMorphoParser nanoMorpho.byaccj
 
 test: NanoMorphoParser.class NanoMorphoLexer.class NanoMorphoParserVal.class
-	echo ""
-	echo ""
-	echo "Testing parser"
+	@echo ""
+	@echo ""
+	@echo "Testing parser"
 	java NanoMorphoParser test_success.s
 
 Generate_morpho: NanoMorphoParser.class NanoMorphoLexer.class NanoMorphoParserVal.class
-	echo ""
-	echo ""
-	echo "Generating morpho from the test file"
+	@echo ""
+	@echo ""
+	@echo "Generating morpho from the test file"
 	java NanoMorphoParser test_success.s | java -jar morpho.jar -c
 
 Test_morpho_generated_code: Generate_morpho
-	echo ""
-	echo ""
-	echo "Executing the morpho code"
+	@echo ""
+	@echo ""
+	@echo "Executing the morpho code"
 	java -jar morpho.jar test_success
 
 gen_ava: NanoMorphoParser.class NanoMorphoLexer.class NanoMorphoParserVal.class
-	echo ""
-	echo ""
-	echo "Generating ava7's nanomorpho"
+	@echo ""
+	@echo ""
+	@echo "Generating ava7's nanomorpho"
 	java NanoMorphoParser ava7.nm | java -jar morpho.jar -c
 
 test_ava: gen_ava
-	echo ""
-	echo ""
-	echo "Testing ava7's nanomorpho"
+	@echo ""
+	@echo ""
+	@echo "Testing ava7's nanomorpho"
 	java -jar morpho.jar ava7
 
 clean:

--- a/nanoMorphoByacc/makefile
+++ b/nanoMorphoByacc/makefile
@@ -24,17 +24,17 @@ test: NanoMorphoParser.class NanoMorphoLexer.class NanoMorphoParserVal.class
 	echo "Testing parser"
 	java NanoMorphoParser test_success.s
 
-Generate_morpho: 
+Generate_morpho:
 	echo ""
 	echo ""
 	echo "Generating morpho from the test file"
 	java NanoMorphoParser test_success.s | java -jar morpho.jar -c
 
-Test_morpho_generated_code: 
+Test_morpho_generated_code:
 	echo ""
 	echo ""
 	echo "Executing the morpho code"
 	java -jar morpho.jar test_success
 
 clean:
-	rm -rf *.class *~ *.mexe *.bak yacc.* *.java  
+	rm -rf *.class *~ *.mexe *.bak yacc.* *.java

--- a/nanoMorphoByacc/nanoMorpho.byaccj
+++ b/nanoMorphoByacc/nanoMorpho.byaccj
@@ -59,17 +59,17 @@ variables
 /* I dont know if its correct way of doing this not sure yet */
 exprs
 	: exprs  expr ';'	 		{ ((Vector<Object>)($1)).add($2); $$=$1; }
-	| expr ';'					{ $$ = new Vector<Object>(); ((Vector<Object>)($$)).add($1); }
+	| expr ';'					  { $$ = new Vector<Object>(); ((Vector<Object>)($$)).add($1); }
 	;
 
 /* pretty basic i just translated what i wrote in jflex to this and it seem to work */
 expr
 	: RETURN expr				{ $$ = new Object[]{EXPRESSION_RETURN, $2}; }
-	| NAME '=' expr				{ $$ = new Object[]{EXPRESSION_STORE, findVar($1), $3}; }
+	| NAME '=' expr			{ $$ = new Object[]{EXPRESSION_STORE, findVar($1), $3}; }
 	| binopexpr 				{ $$ = $1; }
 	;
 
-/* There is something wrong with binopexpr need to check it out abit better */
+/* Binary operations with 8 levels of priority */
 binopexpr
 	: binopexpr OP1 binopexpr	{ $$ = new Object[]{EXPRESSION_CALL, $2 ,new Object[]{$1, $3}};}
 	| binopexpr OP2 binopexpr	{ $$ = new Object[]{EXPRESSION_CALL, $2 ,new Object[]{$1, $3}};}
@@ -78,7 +78,7 @@ binopexpr
 	| binopexpr OP5 binopexpr	{ $$ = new Object[]{EXPRESSION_CALL, $2 ,new Object[]{$1, $3}};}
 	| binopexpr OP6 binopexpr	{ $$ = new Object[]{EXPRESSION_CALL, $2 ,new Object[]{$1, $3}};}
 	| binopexpr OP7 smallexpr	{ $$ = new Object[]{EXPRESSION_CALL, $2 ,new Object[]{$1, $3}};}
-	| smallexpr					{ $$ = $1; }
+	| smallexpr					      { $$ = $1; }
 	;
 
 /* Not 100% sure if op smallexpr %prec UNOP needs to be here or in binopexpr */
@@ -96,7 +96,7 @@ smallexpr
 	  	 exprs
 	  '}'
 	  elseiforelse				{ $$ = new Object[]{EXPRESSION_IF, $3, new Object[]{EXPRESSION_BODY, ((Vector<Object>)($6)).toArray()}, $8}; }
-| op smallexpr %prec UNOP   { $$ = new Object[]{EXPRESSION_CALL, $1 , new Object[]{$2}}; }
+  | op smallexpr %prec UNOP   { $$ = new Object[]{EXPRESSION_CALL, $1 , new Object[]{$2}}; }
 	;
 
 elseiforelse
@@ -130,9 +130,9 @@ elsesent
 	;
 
 commasepExpr
-	: /* empty */ 				{ $$ = new Vector<Object>(); }
+	: /* empty */ 				    { $$ = new Vector<Object>(); }
 	| commasepExpr ',' expr		{ ((Vector<Object>)($1)).add($3); $$=$1; }
-	| expr						{ $$ = new Vector<Object>(); ((Vector<Object>)($$)).add($1); }
+	| expr						        { $$ = new Vector<Object>(); ((Vector<Object>)($$)).add($1); }
 	;
 
 op	:	OP1 | OP2 | OP3 | OP4 | OP5 | OP6 | OP7 ;
@@ -183,9 +183,10 @@ private int yylex()
 
 public void yyerror( String error )
 {
-	System.out.println("Error:  "+error);
-	System.out.println("Token:  "+NanoMorphoParser.yyname[last_token_read]);
-	System.exit(1);
+    System.out.printf("Error:  %s ", error);
+    System.out.printf(" in line: %d, column: %d,", lexer.getLine(), lexer.getColumn());
+    System.out.printf(" last token read:  %s\n", NanoMorphoParser.yyname[last_token_read]);
+    System.exit(1);
 }
 
 public NanoMorphoParser(Reader r)

--- a/nanoMorphoByacc/nanoMorpho.byaccj
+++ b/nanoMorphoByacc/nanoMorpho.byaccj
@@ -6,7 +6,7 @@
 %token <sval> LITERAL,NAME,OP1,OP2,OP3,OP4,OP5,OP6,OP7
 %token VAR,IF,ELSIF,ELSE,WHILE,RETURN,OPNAME
 %type <obj> program, function, exprs, expr, binopexpr, smallexpr, commasepExpr, elseiforelse, elseifsent, elsesent
-%type <ival> funcargs 
+%type <ival> funcargs
 %right RETURN '='
 %left OP1
 %right OP2
@@ -19,12 +19,12 @@
 
 %%
 
-start 
+start
 	: program { generateProgram(name, ((Vector<Object>)($1)).toArray()); }
 	;
 
-/* A program is defined as one or more functions */ 
-program                    
+/* A program is defined as one or more functions */
+program
 	:  program function 	{ ((Vector<Object>)($1)).add($2); $$=$1; }   /* if its more than one function we add it to a vector that is to be returned */
 	|  function { $$=new Vector<Object>(); ((Vector<Object>)($$)).add($1); } /* if its just a single function then we return it */
 	;
@@ -45,9 +45,9 @@ function
 /* count the number of arguments */
 funcargs
 	: /* empty */ 			{ $$ = 0; }
-	| funcargs ',' NAME 	{ addVar($3); $$ = $1 + 1; } 
+	| funcargs ',' NAME 	{ addVar($3); $$ = $1 + 1; }
 	| NAME					{ addVar($1); $$ = 1; }
-	; 
+	;
 
 /* Count the number of variables */
 variables
@@ -69,7 +69,7 @@ expr
 	;
 
 /* There is something wrong with binopexpr need to check it out abit better */
-binopexpr 
+binopexpr
 	: binopexpr OP1 binopexpr	{ $$ = new Object[]{EXPRESSION_CALL, $2 ,new Object[]{$1, $3}};}
 	| binopexpr OP2 binopexpr	{ $$ = new Object[]{EXPRESSION_CALL, $2 ,new Object[]{$1, $3}};}
 	| binopexpr OP3 binopexpr	{ $$ = new Object[]{EXPRESSION_CALL, $2 ,new Object[]{$1, $3}};}
@@ -81,7 +81,7 @@ binopexpr
 	;
 
 /* Not 100% sure if op smallexpr %prec UNOP needs to be here or in binopexpr */
-smallexpr 
+smallexpr
 	: NAME '(' commasepExpr ')' { $$ = new Object[]{EXPRESSION_CALL, $1, ((Vector<Object>)($3)).toArray()}; }
 	| NAME 						{ $$ = new Object[]{EXPRESSION_FETCH, findVar($1)}; }
 	| LITERAL					{ $$ = new Object[]{EXPRESSION_LITERAL, $1}; }
@@ -89,7 +89,7 @@ smallexpr
 	| WHILE '(' expr ')'
 	  '{'
 		  exprs
-	  '}' 						{ $$ = new Object[]{EXPRESSION_WHILE, $3, new Object[]{EXPRESSION_BODY, ((Vector<Object>)($6)).toArray()}}; }  
+	  '}' 						{ $$ = new Object[]{EXPRESSION_WHILE, $3, new Object[]{EXPRESSION_BODY, ((Vector<Object>)($6)).toArray()}}; }
 	| IF '(' expr ')'
 	  '{'
 	  	 exprs
@@ -103,7 +103,7 @@ elseiforelse
 	| elseifsent				{ $$ = $1; }
 	| elsesent					{ $$ = $1; }
 	;
-	
+
 elseifsent
 	: ELSIF '(' expr ')'
 	  '{'
@@ -122,7 +122,7 @@ elseifsent
 	;
 
 elsesent
-	: ELSE 
+	: ELSE
 	  '{'
          exprs
 	  '}'						{ $$ = new Object[]{EXPRESSION_IF, new Object[]{EXPRESSION_LITERAL, "true"}, new Object[]{EXPRESSION_BODY, ((Vector<Object>)($3)).toArray()}, null};}
@@ -205,7 +205,7 @@ public static void main( String args[] ) throws IOException
   --------------------------------------------------------------*/
 
   /*
-	i thought i might of had to change some code in the program generator 
+	i thought i might of had to change some code in the program generator
 	but it seems i dont need to at the moment so it is eaxctly the same as in the previous version
   */
 
@@ -226,7 +226,7 @@ public static void main( String args[] ) throws IOException
 	{
 		System.out.println(line);
     }
-    
+
 	public static int newLabel()
 	{
 		return nextLabel++;
@@ -244,19 +244,17 @@ public static void main( String args[] ) throws IOException
         System.out.println("}}");
         System.out.println("*");
         System.out.println("BASIS;");
-      
     }
 
     public void generateFunction(Object[] f)
     {
-   
         String fname = (String)f[0];
         int argCount = (Integer)f[1];
         int varCount = (Integer)f[2];
-		
-		emit("#\""+fname+"[f"+argCount+"]\" =");
+
+        emit("#\""+fname+"[f"+argCount+"]\" =");
         emit("[");
-      
+
         if(varCount > 0 )
         {
             emit("(MakeVal null)");
@@ -271,7 +269,7 @@ public static void main( String args[] ) throws IOException
            generateExpr((Object[])expr);
         }
         emit("(Return)");
-		emit("];");
+      	emit("];");
     }
 
     public void generateExpr(Object[] expr)
@@ -328,7 +326,7 @@ public static void main( String args[] ) throws IOException
                 emit("(Go _"+labEnd+")");
                 emit("_"+labElse+":");
 
-                /* 
+                /*
                   because the way our code is generated in nanomorhpo.jflex
                   there will be a case where the 3rd value will be null.
                 */
@@ -377,7 +375,7 @@ public static void main( String args[] ) throws IOException
                     generateExprP((Object[])args[i]);
                 }
                 if( i==0 )
-                { 
+                {
                     emit("(Push)");
                 }
                 emit("(Call #\""+(String)((Object[])expr)[1]+"[f"+i+"]\" "+i+")");

--- a/nanoMorphoByacc/nanoMorpho.byaccj
+++ b/nanoMorphoByacc/nanoMorpho.byaccj
@@ -3,9 +3,9 @@
 	import java.util.*;
 %}
 
-%token <sval> LITERAL,NAME,OP1,OP2,OP3,OP4,OP5,OP6,OP7
+%token <sval> LITERAL,NAME,OP1,OP2,OP3,OP4,OP5,OP6,OP7,AND,OR
 %token VAR,IF,ELSIF,ELSE,WHILE,RETURN,OPNAME
-%type <obj> program, function, exprs, expr, binopexpr, smallexpr, commasepExpr, elseiforelse, elseifsent, elsesent
+%type <obj> program, function, exprs, expr, binopexpr, smallexpr, commasepExpr, elseiforelse, elseifsent, elsesent, orexpr, andexpr, notexpr
 %type <ival> funcargs
 %type <sval> op
 %right RETURN '='
@@ -17,6 +17,8 @@
 %left OP6
 %left OP7
 %left UNOP
+%left AND
+%left OR
 
 %%
 
@@ -64,10 +66,27 @@ exprs
 
 /* pretty basic i just translated what i wrote in jflex to this and it seem to work */
 expr
-	: RETURN expr				{ $$ = new Object[]{EXPRESSION_RETURN, $2}; }
-	| NAME '=' expr			{ $$ = new Object[]{EXPRESSION_STORE, findVar($1), $3}; }
-	| binopexpr 				{ $$ = $1; }
-	;
+  : RETURN expr				{ $$ = new Object[]{EXPRESSION_RETURN, $2}; }
+  | NAME '=' expr			{ $$ = new Object[]{EXPRESSION_STORE, findVar($1), $3}; }
+  | orexpr    				{ $$ = $1; }
+  ;
+
+/* One or more AND expressions with OR tokens between them */
+orexpr
+  : andexpr OR orexpr { $$ = new Object[]{EXPRESSION_CALL, $2, new Object[]{$1,$3}}; }
+  | andexpr           { $$ = $1; }
+  ;
+
+/* One or more NOT expressions with AND tokens between them*/
+andexpr
+  : notexpr AND andexpr { $$ = new Object[]{EXPRESSION_CALL, $2, new Object[]{$1,$3}}; }
+  | notexpr            { $$ = $1; }
+  ;
+
+/* Binop expressions with or without a NOT prefix (!)*/
+notexpr
+  : '!' notexpr  { $$ = new Object[]{EXPRESSION_CALL, "!", new Object[]{$2} }; }
+  | binopexpr    { $$ = $1; }
 
 /* Binary operations with 8 levels of priority */
 binopexpr
@@ -329,7 +348,7 @@ public static void main( String args[] ) throws IOException
                 emit("_"+labElse+":");
 
                 /*
-                  because the way our code is generated in nanomorhpo.jflex
+                  because the way our code is generated in nanomorpho.jflex
                   there will be a case where the 3rd value will be null.
                 */
                 if(((Object[])(((Object[])expr)[3])) != null)

--- a/nanoMorphoByacc/nanoMorpho.byaccj
+++ b/nanoMorphoByacc/nanoMorpho.byaccj
@@ -7,6 +7,7 @@
 %token VAR,IF,ELSIF,ELSE,WHILE,RETURN,OPNAME
 %type <obj> program, function, exprs, expr, binopexpr, smallexpr, commasepExpr, elseiforelse, elseifsent, elsesent
 %type <ival> funcargs
+%type <sval> op
 %right RETURN '='
 %left OP1
 %right OP2
@@ -95,7 +96,7 @@ smallexpr
 	  	 exprs
 	  '}'
 	  elseiforelse				{ $$ = new Object[]{EXPRESSION_IF, $3, new Object[]{EXPRESSION_BODY, ((Vector<Object>)($6)).toArray()}, $8}; }
-	| op smallexpr %prec UNOP   { $$ = $2; }
+| op smallexpr %prec UNOP   { $$ = new Object[]{EXPRESSION_CALL, $1 , new Object[]{$2}}; }
 	;
 
 elseiforelse

--- a/nanoMorphoByacc/nanoMorpho.jflex
+++ b/nanoMorphoByacc/nanoMorpho.jflex
@@ -16,6 +16,9 @@
 
 public NanoMorphoParser yyparser;
 
+public int getLine() { return yyline+1; }
+public int getColumn() { return yycolumn+1; }
+
 public NanoMorphoLexer(java.io.Reader r, NanoMorphoParser yyparser )
 {
 	this(r);

--- a/nanoMorphoByacc/nanoMorpho.jflex
+++ b/nanoMorphoByacc/nanoMorpho.jflex
@@ -33,6 +33,8 @@ _INT={_DIGIT}+
 _STRING=\"([^\"\\]|\\b|\\t|\\n|\\f|\\r|\\\"|\\\'|\\\\|(\\[0-3][0-7][0-7])|\\[0-7][0-7]|\\[0-7])*\"
 _CHAR=\'([^\'\\]|\\b|\\t|\\n|\\f|\\r|\\\"|\\\'|\\\\|(\\[0-3][0-7][0-7])|(\\[0-7][0-7])|(\\[0-7]))\'
 _DELIM=[(){},;=]
+_AND=&&
+_OR=\|\|
 _NAME=([:letter:]|\_|{_DIGIT})+
 _OPNAME=[\+\-*/!%&=><\:\^\~&|?]+
 
@@ -41,6 +43,16 @@ _OPNAME=[\+\-*/!%&=><\:\^\~&|?]+
 {_DELIM} {
 	yyparser.yylval = new NanoMorphoParserVal(yytext());
 	return yycharat(0);
+}
+
+{_AND} {
+    yyparser.yylval = new NanoMorphoParserVal(yytext());
+    return NanoMorphoParser.AND;
+}
+
+{_OR} {
+    yyparser.yylval = new NanoMorphoParserVal(yytext());
+    return NanoMorphoParser.OR;
 }
 
 {_STRING} | {_FLOAT} | {_CHAR} | {_INT} | null | true | false {

--- a/nanoMorphoByacc/nanoMorpho.jflex
+++ b/nanoMorphoByacc/nanoMorpho.jflex
@@ -9,7 +9,7 @@
 %class NanoMorphoLexer
 %byaccj
 %line
-%column 
+%column
 %unicode
 
 %{

--- a/nanoMorphoByacc/test_success.s
+++ b/nanoMorphoByacc/test_success.s
@@ -10,11 +10,11 @@ string_Tests()
 {
 	var x,y;
 	y = " Hi Back at you";
-	x = "Hello world";	
-	writeln(x);			
-	x = "Hello again";			
-	writeln(x);	
-	
+	x = "Hello world";
+	writeln(x);
+	x = "Hello again";
+	writeln(x);
+
 	writeln("ABC"++"DEF");
 	writeln(x++y);
 	newLine();
@@ -22,9 +22,9 @@ string_Tests()
 
 ;;; TESTS :
 ;;; - variable assignment
-;;; - Adding integers and variables 
+;;; - Adding integers and variables
 ;;; - concatenation of string and integers
-;;; - floating point math 
+;;; - floating point math
 math_Tests()
 {
 	var a,b,c;
@@ -40,11 +40,11 @@ math_Tests()
 
 ;;; TESTS :
 ;;; - variable assignment
-;;; - creating list with integers and null 
+;;; - creating list with integers and null
 ;;; - creating list with integers
 ;;; - creating list with strings
 ;;; - creating list from from variable values
-;;; - creating list from functions that return values 
+;;; - creating list from functions that return values
 list_Tests()
 {
 	var x,y,z,m;
@@ -70,7 +70,7 @@ list_Tests()
 
 ;;; TESTS :
 ;;; - reciving and using arguments
-;;; - condional flows 
+;;; - condional flows
 ;;; - body expressions inside IF statements
 conditional_Tests(first,second)
 {
@@ -79,21 +79,21 @@ conditional_Tests(first,second)
 	{
 		if(second)
 		{
-			writeln("resutl: first="++first++" second="++ second);
+			writeln("result: first="++first++" second="++ second);
 		}
 		else
 		{
-			writeln("resutl: first="++first++" second="++ second);
+			writeln("result: first="++first++" second="++ second);
 		};
 	}
 	else{
 		if(second)
 		{
-			writeln("resutl: first="++first++" second="++ second);
+			writeln("result: first="++first++" second="++ second);
 		}
 		else
 		{
-			writeln("resutl: first="++first++" second="++ second);
+			writeln("result: first="++first++" second="++ second);
 		};
 	};
 
@@ -180,6 +180,6 @@ main()
 	conditional_Tests(false,false);
 	edgecase_conditional_Tests(true);
 	edgecase_conditional_Tests(false);
-	writeln("none-recursive fibo(35)="++fibo(35));
+	writeln("non-recursive fibo(35)="++fibo(35));
 	writeln("recursive fibo(35)="++f(35));
 }


### PR DESCRIPTION
Changelist:

- Unary operators now generate the necessary BASIS function signatures
- Change makefile so that the default target compiles the project.
  Dependencies added to different targets as necessary.
- Refactor yyerrror() to utilize line and column information.
  Output is in a single line
- Refactor the lexer to tokenize && and || to AND and OR respectively
- Implement expr -> orexpr -> andexpr -> notexpr -> binopexpr 